### PR TITLE
Load-balancing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 [![backend](https://github.com/noteable-io/minor-illusion/actions/workflows/backend-tests.yaml/badge.svg)](https://github.com/noteable-io/minor-illusion/actions/workflows/backend-tests.yaml) [![Docs](https://github.com/noteable-io/minor-illusion/actions/workflows/publish-docs.yaml/badge.svg)](https://noteable-io.github.io/minor-illusion/)
 
-This is a toy `Todo` application that uses some of the same frameworks as our production code.  For the Noteable engineering team, it may be useful for demonstrating fundamental concepts, onboarding, or reproducing minimal errors.  It's worth noting that DevOps is not represented here, this repo uses `docker-compose` for convenience over standing up a local kubernetes cluster.  For anyone interested in Noteable, here's a peek into the stack you would be working with:
+This is a toy `Todo` application that uses some of the same frameworks and concepts as our production code.  For the Noteable engineering team, this repo can be useful for onboarding, reproducing bugs for external partners, and prototyping systemic changes.  For anyone interested in Noteable, here's a peek into the stack you would be working with:
 
   * Backend:
     * [Hypercorn](https://pgjones.gitlab.io/hypercorn/) for the [ASGI](https://asgi.readthedocs.io/en/latest/) server
@@ -36,19 +36,23 @@ This is a toy `Todo` application that uses some of the same frameworks as our pr
 
   * Docs:
     * [mkdocs](https://www.mkdocs.org/)
+
+  * Reverse-Proxy:
+    * [Traefik](https://traefik.io/) for reverse-proxy and load-balancing between backend instances
   
 
 ## Run
 
 Clone this repository and `docker-compose up -d`.  See [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/) documentation for installing those services if they aren't already on your development machine.  You can tail the logs for all services with `docker-compose logs -f`.
 
-There are four services that will start up:
-    1. Frontend (NextJS) UI that you can reach at `http://localhost:3000`
-    2. Backend (FastAPI) app that you can reach at `http://localhost:8000`, see `http://localhost:8000/docs` for OpenAPI/swagger
-    3. CockroachDB that is inacessible from outside of the Docker network
-    4. Jupyter Notebook container that you can reach at `http://localhost:8888`, although you'll need to look at `docker-compose logs jupyter` to get the url + access token (something like `http://127.0.0.1:8888/?token=c2a1a877ca8ad47818bd76df917d7aaeca6d8f4a17cb462e`)
+There are five services that will start up:
+    1. A reverse proxy / load-balance web-server (Traefik), transparent to an end user
+    2. Frontend (NextJS) UI that you can reach at `http://localhost:5000`
+    3. A pair of load-balanced Backend (FastAPI) apps that you can reach at `http://localhost:5000/api`, see `http://localhost:5000/api/docs` for OpenAPI/swagger
+    4. CockroachDB that is inacessible from outside of the Docker network
+    5. Jupyter Notebook container that you can reach at `http://localhost:8888`, although you'll need to look at `docker-compose logs jupyter` to get the url + access token (something like `http://127.0.0.1:8888/?token=c2a1a877ca8ad47818bd76df917d7aaeca6d8f4a17cb462e`)
 
-*The backend app will not be accessible until after Cockroach DB is online, accepting connections, and has gone through Alembic migrations.  Expect a 30-60 second delay between containers starting and being able to access `http://localhost:8000/docs`.  If the backend has a timeout error, try `docker-compose up -d backend` once the cockroach DB says it is accepting connections.*
+*The backend app will not be accessible until after Cockroach DB is online, accepting connections, and has gone through Alembic migrations.  Expect a 30-60 second delay between containers starting and being able to access `http://localhost:5000/api/docs`*
 
 ## Docs
 

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import Depends, FastAPI
 
 from app.auth import get_user
@@ -6,9 +8,10 @@ from app.crud import router as CrudRouter
 from app.log_utils import setup_logging
 from app.models import UserDAO
 from app.schemas import UserOut
+from app.settings import get_settings
 
 setup_logging()
-app = FastAPI()
+app = FastAPI(root_path=get_settings().ROOT_PATH)
 app.include_router(AuthRouter)
 app.include_router(CrudRouter)
 
@@ -16,3 +19,10 @@ app.include_router(CrudRouter)
 @app.get("/me", response_model=UserOut)
 def me(user: UserDAO = Depends(get_user)):
     return user
+
+
+# Useful for seeing which backend your browser is connected to
+# when multiple backends are running behind load-balancer.
+@app.get("/host")
+def environ():
+    return os.environ.get("HOSTNAME")

--- a/backend/src/app/settings.py
+++ b/backend/src/app/settings.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Optional
 
 from pydantic import BaseSettings
 
@@ -7,6 +8,7 @@ class Settings(BaseSettings):
     DB_DSN: str = "cockroachdb+asyncpg://root@cockroach:26257/defaultdb"
     LOG_LEVEL: str = "INFO"
     LOGS_AS_JSON: bool = False
+    ROOT_PATH: Optional[str] = None
 
 
 @lru_cache

--- a/backend/src/cast.sh
+++ b/backend/src/cast.sh
@@ -1,7 +1,11 @@
+#!/bin/bash
+
 set -e
 
 wait-for cockroach:26257 -- echo "Cockroach is up"
 
-poetry run alembic upgrade head 
+if [[ -n "$RUN_ALEMBIC" ]]; then
+    poetry run alembic upgrade head 
+fi
 
 poetry run python -m debugpy --listen 0.0.0.0:5678 -m uvicorn app.main:app --reload --host 0.0.0.0

--- a/backend/src/tests/demo_db/conftest.py
+++ b/backend/src/tests/demo_db/conftest.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession, create_async_e
 from sqlalchemy.orm import sessionmaker
 
 # shell command to launch ephemeral *in-memory* cockroach db
-COCKROACH_CMD = """cockroach demo --sql-port 26259 --no-example-database -e 'ALTER USER demo with password "noteable";select pg_sleep(1000)'"""
+COCKROACH_CMD = """cockroach demo --sql-port 26259 --http-port 8001 --no-example-database -e 'ALTER USER demo with password "noteable";select pg_sleep(1000)'"""
 
 # these should match with the COCKROACH_CMD values
 TEST_DB_USER = "demo"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,16 +1,37 @@
 version: '3.8'
 
 services:
-  backend:
+  backend1:
     build: ./backend
     ports:
-      - 5678:5678 # to attach debug
-      - 8000:8000 # actual webapp
+      - 5678:5678
     volumes:
       - ./backend/src/app:/usr/src/app
       - ./backend/src/tests:/usr/src/tests
       - ./backend/src/migrations/versions:/usr/src/migrations/versions
+    environment:
+      ROOT_PATH: "/api"
+      RUN_ALEMBIC: 1
+    restart: always
 
+  backend2:
+    build: ./backend
+    volumes:
+      - ./backend/src/app:/usr/src/app
+      - ./backend/src/tests:/usr/src/tests
+      - ./backend/src/migrations/versions:/usr/src/migrations/versions
+    environment:
+      ROOT_PATH: "/api"
+    restart: always
+
+  proxy:
+    image: traefik:latest
+    volumes:
+      - ./proxy:/etc/traefik
+    ports:
+      - 5000:5000
+      - 8080:8080
+    
   cockroach:
     image: cockroachdb/cockroach-unstable:v21.2.0-beta.4
     command: start-single-node --insecure --listen-addr=0.0.0.0:26257
@@ -27,8 +48,6 @@ services:
 
   frontend:
     build: ./frontend
-    ports:
-      - 3000:3000
     volumes:
       # I'd love to just mount ./frontend/minor-illusion:/app
       # but it is volume hell with node_modules and .next directories

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -6,7 +6,7 @@
 
 **The stack**
 
-* Backend:
+  * Backend:
     * [Hypercorn](https://pgjones.gitlab.io/hypercorn/) for the [ASGI](https://asgi.readthedocs.io/en/latest/) server
     * [FastAPI](https://fastapi.tiangolo.com/) for the web framework
     * [Pydantic](https://pydantic-docs.helpmanual.io/) for data validation
@@ -30,3 +30,6 @@
 
   * Docs:
     * [mkdocs](https://www.mkdocs.org/)
+
+  * Reverse-Proxy:
+    * [Traefik](https://traefik.io/) for reverse-proxy and load-balancing between backend instances

--- a/docs/docs/traefik.md
+++ b/docs/docs/traefik.md
@@ -1,0 +1,10 @@
+# Traefik
+
+[Traefik](https://traefik.io/) in this repo acts as a reverse-proxy and load-balancer.  In a production Kubernetes environment, those two behaviors would be handled in the infrastructure by ingress managers and services.  Do not focus too much on Traefik in this repository in terms of understanding production Noteable code.  It is included here in order to support demonstrating real-time-updates (RTU) between backend servers (and users connected to different backend servers) over websockets and redis.
+
+Traefik is typically advertised as a way to do dynamic edge routing, for instance by monitoring what containers are alive in Docker and dynamically creating routes to those containers based on Labels.  For this example though, the routing / services / middleware configuration is all file-based in `proxy/traefik.yaml` and files in `proxy/dynamic/`.  
+
+You can see a nice dashboard representing those configurations at `http://localhost:8080/dashboard/`.
+
+
+

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,4 +3,5 @@ site_name: Minor-Illusion
 nav:
   - index.md
   - backend.md
+  - traefik.md
       

--- a/proxy/dynamic/backend.yaml
+++ b/proxy/dynamic/backend.yaml
@@ -1,0 +1,22 @@
+http:
+  routers:
+    backend:
+      rule: "PathPrefix(`/api`)"
+      service: backend-service
+      entryPoints:
+        - web
+      middlewares:
+        - strip-api-prefix
+
+  services: 
+    backend-service:
+      loadBalancer:
+        servers:
+          - url: "http://backend1:8000/"
+          - url: "http://backend2:8000/"
+
+  middlewares:  
+    strip-api-prefix:
+      stripPrefix:
+        prefixes:
+          - "/api"

--- a/proxy/dynamic/dashboard.yaml
+++ b/proxy/dynamic/dashboard.yaml
@@ -1,0 +1,7 @@
+http:
+  routers:
+    dashboard:
+      rule: "PathPrefix(`/api`) || PathPrefix(`/dashboard`)"
+      service: api@internal
+      entryPoints:
+        - "traefik"

--- a/proxy/dynamic/frontend.yaml
+++ b/proxy/dynamic/frontend.yaml
@@ -1,0 +1,13 @@
+http:
+  routers:
+    frontend:
+      rule: "PathPrefix(`/`)"
+      service: frontend-service
+      entryPoints:  
+        - web
+
+  services: 
+    frontend-service:
+      loadBalancer:
+        servers:
+          - url: "http://frontend:3000"

--- a/proxy/traefik.yaml
+++ b/proxy/traefik.yaml
@@ -1,0 +1,19 @@
+# Static configuration for Traefik
+# https://doc.traefik.io/traefik/getting-started/configuration-overview/#the-static-configuration
+
+entryPoints:
+  web:
+    address: ":5000"
+
+api:
+  dashboard: true
+  insecure: true
+
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+
+logs:
+  level: DEBUG
+
+accessLog: {}


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present if applicable
- [ ] Integration tests (Notebooks) are present if applicable

## Summary of Changes

This is the first step towards representing RTU in `minor-illusion`.  The next step is to add websockets for real-time client/server updates, and redis for backend-backend updates.  Once that is done, it'll supply a good real world use case to develop against `asyncapi-eventrouter`.  

## What is the Current Behavior?

- There is a single backend container
- Frontendcontainer available at `localhost:3000`
- Backend container available at `localhost:8000`

## What is the New Behavior?

- Frontend available at `localhost:5000` (traefik -> frontend container)
- Backend available at `localhost:5000/api` (traefik load balancing between two backend containers)
- Only one backend runs alembic
- Backends are aware of running in sub-directory using `ROOT_PATH` env variable/settings option
- Traefik configs in new directory `proxy/`
- Traefik dashboard available at `localhost:8080`

