### PR TITLE
[WIP] Websocket endpoint at /rtu

### DIFF
--- a/backend/src/app/auth.py
+++ b/backend/src/app/auth.py
@@ -24,13 +24,13 @@ async def login(form_data: OAuth2PasswordRequestForm = Depends()):
     if not db_user.password == form_data.password:
         raise HTTPException(status.HTTP_403_FORBIDDEN, detail="Incorrect password")
     # delegate token creation partly to make testing easier
-    return create_token(db_user.name)
+    jwt_token = create_token(db_user.name)
+    return {"access_token": jwt_token, "token_type": "bearer"}
 
 
 def create_token(username: str):
     "Create a JWT token for the given username"
-    encoded_key = jwt.encode({"user": username}, SECRET_KEY, algorithm=ALGORITHM)
-    return {"access_token": encoded_key, "token_type": "bearer"}
+    return jwt.encode({"user": username}, SECRET_KEY, algorithm=ALGORITHM)
 
 
 async def get_user(token: str = Depends(oauth2_scheme)):

--- a/backend/src/app/main.py
+++ b/backend/src/app/main.py
@@ -7,13 +7,24 @@ from app.auth import router as AuthRouter
 from app.crud import router as CrudRouter
 from app.log_utils import setup_logging
 from app.models import UserDAO
+from app.rtu import router as RtuRouter
 from app.schemas import UserOut
 from app.settings import get_settings
 
 setup_logging()
-app = FastAPI(root_path=get_settings().ROOT_PATH)
-app.include_router(AuthRouter)
-app.include_router(CrudRouter)
+
+
+def build_app() -> FastAPI:
+    "Builds the minor-illusion FastAPI application"
+    # this is encapsulated in a function to assist with testing
+    app = FastAPI(root_path=get_settings().ROOT_PATH)
+    app.include_router(AuthRouter)
+    app.include_router(CrudRouter)
+    app.include_router(RtuRouter)
+    return app
+
+
+app = build_app()
 
 
 @app.get("/me", response_model=UserOut)

--- a/backend/src/app/rtu.py
+++ b/backend/src/app/rtu.py
@@ -1,0 +1,92 @@
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from pydantic import BaseModel, Field
+
+from app.auth import get_user
+from app.schemas import UserOut
+
+# NOTE: Websockets attached to an APIRouter with a prefix
+# will fail and always return 403.
+# See https://github.com/tiangolo/fastapi/issues/98
+# For now, skip prefix and just make sure to include
+# /rtu in the appropriate paths
+
+router = APIRouter(tags=["rtu"])
+
+
+class RTUData(BaseModel):
+    class Config:
+        extra = "allow"
+
+
+class RTURequest(BaseModel):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    event: str
+    data: Optional[RTUData]
+
+    class Config:
+        json_encoders = {uuid.UUID: lambda v: str(v)}
+
+
+class RTUReply(BaseModel):
+    id: uuid.UUID = Field(default_factory=uuid.uuid4)
+    req_id: uuid.UUID
+    data: Optional[RTUData]
+
+    class Config:
+        json_encoders = {uuid.UUID: lambda v: str(v)}
+
+
+class WebsocketSession:
+    def __init__(self, websocket: WebSocket):
+        self.websocket = websocket
+        self.n_read = 0
+        self.n_written = 0
+        self.user = None
+
+    async def auth_user(self, token: str):
+        self.user = await get_user(token)
+        return UserOut.from_orm(self.user).dict()
+
+    async def session_stats(self):
+        return {
+            "n_read": self.n_read,
+            "n_written": self.n_written,
+            "user": self.user.name if self.user else "Not authenticated",
+        }
+
+    async def process(self, message: dict):
+        req = RTURequest(**message)
+        if req.event == "auth":
+            data = await self.auth_user(req.data.token)
+            response = RTUReply(req_id=req.id, data=RTUData(**data))
+        elif req.event == "session_stats":
+            data = await self.session_stats()
+            response = RTUReply(req_id=req.id, data=RTUData(**data))
+        return response
+
+    async def listen(self):
+        while True:
+            try:
+                message = await self.websocket.receive_json()
+                self.n_read += 1
+                response = await self.process(message)
+                await self.websocket.send_text(response.json())
+                self.n_written += 1
+            except WebSocketDisconnect:
+                break
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+@router.websocket("/rtu")
+async def rtu(websocket: WebSocket):
+    await websocket.accept()
+    async with WebsocketSession(websocket) as session:
+        await session.listen()

--- a/backend/src/poetry.lock
+++ b/backend/src/poetry.lock
@@ -863,6 +863,14 @@ python-versions = ">=3.6"
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "websockets"
+version = "10.1"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "zipp"
 version = "3.6.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -877,7 +885,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e38de73a5381643a0e99dc49cf1cb97e8873fb3a777ff93b437b9ab6d2285d05"
+content-hash = "98a0cc50623b62649b4eea28d5653d0d890e737089068d7c4ff91ba89c0b4f7f"
 
 [metadata.files]
 alembic = [
@@ -1576,6 +1584,56 @@ watchdog = [
     {file = "watchdog-2.1.6-py3-none-win_amd64.whl", hash = "sha256:bd9ba4f332cf57b2c1f698be0728c020399ef3040577cde2939f2e045b39c1e5"},
     {file = "watchdog-2.1.6-py3-none-win_ia64.whl", hash = "sha256:a0f1c7edf116a12f7245be06120b1852275f9506a7d90227648b250755a03923"},
     {file = "watchdog-2.1.6.tar.gz", hash = "sha256:a36e75df6c767cbf46f61a91c70b3ba71811dfa0aca4a324d9407a06a8b7a2e7"},
+]
+websockets = [
+    {file = "websockets-10.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:38db6e2163b021642d0a43200ee2dec8f4980bdbda96db54fde72b283b54cbfc"},
+    {file = "websockets-10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e1b60fd297adb9fc78375778a5220da7f07bf54d2a33ac781319650413fc6a60"},
+    {file = "websockets-10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3477146d1f87ead8df0f27e8960249f5248dceb7c2741e8bbec9aa5338d0c053"},
+    {file = "websockets-10.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb01ea7b5f52e7125bdc3c5807aeaa2d08a0553979cf2d96a8b7803ea33e15e7"},
+    {file = "websockets-10.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:9fd62c6dc83d5d35fb6a84ff82ec69df8f4657fff05f9cd6c7d9bec0dd57f0f6"},
+    {file = "websockets-10.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3bbf080f3892ba1dc8838786ec02899516a9d227abe14a80ef6fd17d4fb57127"},
+    {file = "websockets-10.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5560558b0dace8312c46aa8915da977db02738ac8ecffbc61acfbfe103e10155"},
+    {file = "websockets-10.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:667c41351a6d8a34b53857ceb8343a45c85d438ee4fd835c279591db8aeb85be"},
+    {file = "websockets-10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:468f0031fdbf4d643f89403a66383247eb82803430b14fa27ce2d44d2662ca37"},
+    {file = "websockets-10.1-cp310-cp310-win32.whl", hash = "sha256:d0d81b46a5c87d443e40ce2272436da8e6092aa91f5fbeb60d1be9f11eff5b4c"},
+    {file = "websockets-10.1-cp310-cp310-win_amd64.whl", hash = "sha256:b68b6caecb9a0c6db537aa79750d1b592a841e4f1a380c6196091e65b2ad35f9"},
+    {file = "websockets-10.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a249139abc62ef333e9e85064c27fefb113b16ffc5686cefc315bdaef3eefbc8"},
+    {file = "websockets-10.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8877861e3dee38c8d302eee0d5dbefa6663de3b46dc6a888f70cd7e82562d1f7"},
+    {file = "websockets-10.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e3872ae57acd4306ecf937d36177854e218e999af410a05c17168cd99676c512"},
+    {file = "websockets-10.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b66e6d514f12c28d7a2d80bb2a48ef223342e99c449782d9831b0d29a9e88a17"},
+    {file = "websockets-10.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:9f304a22ece735a3da8a51309bc2c010e23961a8f675fae46fdf62541ed62123"},
+    {file = "websockets-10.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:189ed478395967d6a98bb293abf04e8815349e17456a0a15511f1088b6cb26e4"},
+    {file = "websockets-10.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:08a42856158307e231b199671c4fce52df5786dd3d703f36b5d8ac76b206c485"},
+    {file = "websockets-10.1-cp37-cp37m-win32.whl", hash = "sha256:3ef6f73854cded34e78390dbdf40dfdcf0b89b55c0e282468ef92646fce8d13a"},
+    {file = "websockets-10.1-cp37-cp37m-win_amd64.whl", hash = "sha256:89e985d40d407545d5f5e2e58e1fdf19a22bd2d8cd54d20a882e29f97e930a0a"},
+    {file = "websockets-10.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:002071169d2e44ce8eb9e5ebac9fbce142ba4b5146eef1cfb16b177a27662657"},
+    {file = "websockets-10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cfae282c2aa7f0c4be45df65c248481f3509f8c40ca8b15ed96c35668ae0ff69"},
+    {file = "websockets-10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:97b4b68a2ddaf5c4707ae79c110bfd874c5be3c6ac49261160fb243fa45d8bbb"},
+    {file = "websockets-10.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c9407719f42cb77049975410490c58a705da6af541adb64716573e550e5c9db"},
+    {file = "websockets-10.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1d858fb31e5ac992a2cdf17e874c95f8a5b1e917e1fb6b45ad85da30734b223f"},
+    {file = "websockets-10.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7bdd3d26315db0a9cf8a0af30ca95e0aa342eda9c1377b722e71ccd86bc5d1dd"},
+    {file = "websockets-10.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e259be0863770cb91b1a6ccf6907f1ac2f07eff0b7f01c249ed751865a70cb0d"},
+    {file = "websockets-10.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6b014875fae19577a392372075e937ebfebf53fd57f613df07b35ab210f31534"},
+    {file = "websockets-10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:98de71f86bdb29430fd7ba9997f47a6b10866800e3ea577598a786a785701bb0"},
+    {file = "websockets-10.1-cp38-cp38-win32.whl", hash = "sha256:3a02ab91d84d9056a9ee833c254895421a6333d7ae7fff94b5c68e4fa8095519"},
+    {file = "websockets-10.1-cp38-cp38-win_amd64.whl", hash = "sha256:7d6673b2753f9c5377868a53445d0c321ef41ff3c8e3b6d57868e72054bfce5f"},
+    {file = "websockets-10.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ddab2dc69ee5ae27c74dbfe9d7bb6fee260826c136dca257faa1a41d1db61a89"},
+    {file = "websockets-10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:14e9cf68a08d1a5d42109549201aefba473b1d925d233ae19035c876dd845da9"},
+    {file = "websockets-10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e4819c6fb4f336fd5388372cb556b1f3a165f3f68e66913d1a2fc1de55dc6f58"},
+    {file = "websockets-10.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:05e7f098c76b0a4743716590bb8f9706de19f1ef5148d61d0cf76495ec3edb9c"},
+    {file = "websockets-10.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5bb6256de5a4fb1d42b3747b4e2268706c92965d75d0425be97186615bf2f24f"},
+    {file = "websockets-10.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:888a5fa2a677e0c2b944f9826c756475980f1b276b6302e606f5c4ff5635be9e"},
+    {file = "websockets-10.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6fdec1a0b3e5630c58e3d8704d2011c678929fce90b40908c97dfc47de8dca72"},
+    {file = "websockets-10.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:531d8eb013a9bc6b3ad101588182aa9b6dd994b190c56df07f0d84a02b85d530"},
+    {file = "websockets-10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0d93b7cadc761347d98da12ec1930b5c71b2096f1ceed213973e3cda23fead9c"},
+    {file = "websockets-10.1-cp39-cp39-win32.whl", hash = "sha256:d9b245db5a7e64c95816e27d72830e51411c4609c05673d1ae81eb5d23b0be54"},
+    {file = "websockets-10.1-cp39-cp39-win_amd64.whl", hash = "sha256:882c0b8bdff3bf1bd7f024ce17c6b8006042ec4cceba95cf15df57e57efa471c"},
+    {file = "websockets-10.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:10edd9d7d3581cfb9ff544ac09fc98cab7ee8f26778a5a8b2d5fd4b0684c5ba5"},
+    {file = "websockets-10.1-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:baa83174390c0ff4fc1304fbe24393843ac7a08fdd59295759c4b439e06b1536"},
+    {file = "websockets-10.1-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:483edee5abed738a0b6a908025be47f33634c2ad8e737edd03ffa895bd600909"},
+    {file = "websockets-10.1-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:816ae7dac2c6522cfa620947ead0ca95ac654916eebf515c94d7c28de5601a6e"},
+    {file = "websockets-10.1-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1dafe98698ece09b8ccba81b910643ff37198e43521d977be76caf37709cf62b"},
+    {file = "websockets-10.1.tar.gz", hash = "sha256:181d2b25de5a437b36aefedaf006ecb6fa3aa1328ec0236cdde15f32f9d3ff6d"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/backend/src/pyproject.toml
+++ b/backend/src/pyproject.toml
@@ -19,6 +19,7 @@ sqlalchemy-cockroachdb = "^1.4.3"
 structlog = "^21.4.0"
 uvicorn = "^0.15.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
+websockets = "^10.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/backend/src/tests/demo_db/test_rtu.py
+++ b/backend/src/tests/demo_db/test_rtu.py
@@ -1,0 +1,41 @@
+from typing import AsyncContextManager, Callable
+
+import pytest
+from app.models import UserDAO
+from app.rtu import RTUData, RTUReply, RTURequest
+from pytest_mock import MockerFixture
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.testclient import WebSocketTestSession
+
+
+@pytest.mark.asyncio
+class TestRTU:
+    @pytest.fixture(autouse=True)
+    def patch_auth_file(
+        self,
+        mocker: MockerFixture,
+        db_session: Callable[[], AsyncContextManager[AsyncSession]],
+    ):
+        mocker.patch("app.auth.db_session", db_session)
+
+    async def test_rtu(self, ws_client: WebSocketTestSession):
+        req = RTURequest(event="session_stats")
+        ws_client.send_text(req.json())
+        response_js = ws_client.receive_json()
+        response = RTUReply(**response_js)
+        assert response.req_id == req.id
+        assert response.data.user == "Not authenticated"
+        assert response.data.n_read == 1
+        assert response.data.n_written == 0
+
+    async def test_valid_login(
+        self, ws_client: WebSocketTestSession, auth_token: str, fake_user: UserDAO
+    ):
+
+        req = RTURequest(event="auth", data=RTUData(token=auth_token))
+        ws_client.send_text(req.json())
+        response_js = ws_client.receive_json()
+        response = RTUReply(**response_js)
+        assert response.req_id == req.id
+        assert response.data.id == fake_user.id
+        assert response.data.name == fake_user.name


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Unit tests are present if applicable
- [ ] Integration tests (Notebooks) are present if applicable

## Summary of Changes

This is the next incremental step in emulating RTU and perhaps doing development on `asyncapi-eventrouter` or whatever that becomes.  This adds a websocket endpoint at `/rtu` to the Backend FastAPI app.

## What is the Current Behavior?

There is no websocket endpoint.

## What is the New Behavior?

When a user connects to `ws://app/rtu`, it begins a persistent websocket session.  The user can send over RTU Requests and receive RTU replies for events `auth` and `session_stats`.  There are `RTURequest` and `RTUReply` models and optional `RTUData` within those.  The schema and `WebsocketSession` class are very likely to change, so I'm not worried about too much documentation on them right now.

## Blocker

Right now, the test function for the websocket `auth` event is not working.  It raises an error,

```
RuntimeError: Task <Task pending name='anyio.from_thread.BlockingPortal._call_func' coro=<BlockingPortal._call_func() running at /home/kafonek/minor-illusion/backend/src/.venv/lib/python3.8/site-packages/anyio/from_thread.py:187> cb=[TaskGroup._spawn.<locals>.task_done() at /home/kafonek/minor-illusion/backend/src/.venv/lib/python3.8/site-packages/anyio/_backends/_asyncio.py:629]> got Future <Future pending cb=[Protocol._on_waiter_completed()]> attached to a different loop

asyncpg/protocol/protocol.pyx:168: RuntimeError
```

FastAPI recommends using `httpx.AsyncClient` to build a test client and consume the ASGI app when you need to run async tests, https://fastapi.tiangolo.com/advanced/async-tests/#httpx.  Unfortunately, `httpx.AsyncClient` does not have have a websocket entrypoint like the `starlette` / `fastapi` `TestClient`.  There may be a blocking bug here where asynchronous sqlalchemy queries are only possible if the test client consumes the ASGI app asynchronously, but there's no async test client that can enter into a websocket context.